### PR TITLE
removing python versions. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.4"
+  - "2.7"
 cache: pip
 install:
   - python setup.py install


### PR DESCRIPTION
Let's keep it simple for now, and run tests only for python version 2.7. 