### PR TITLE
Fix & Add

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Sam will then ask you for an OpenWeatherMap API key. You can create one by signi
 The action works with the English Weather skill that you can download on [Snips' console](https://console.snips.ai)
 
 ## Locale
-> ***Please do not forget that you have to select one of the following value and give it to `config.ini` -> `locale=`. Otherwise, it will not work.***
+> ***BEWARE: Please do not forget that you have to specify one of the following values as the locale setting during the installation. If you install it manually, please do give this setting to `config.ini` -> `locale=`. Otherwise, it will not work as expected.***
 
 To have the skills properly working, you **need** to generate locales for your languages.  So far the supported locales are:
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Sam will then ask you for an OpenWeatherMap API key. You can create one by signi
 The action works with the English Weather skill that you can download on [Snips' console](https://console.snips.ai)
 
 ## Locale
+> ***Please do not forget that you have to select one of the following value and give it to `config.ini` -> `locale=`. Otherwise, it will not work.***
 
 To have the skills properly working, you **need** to generate locales for your languages.  So far the supported locales are:
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ To have the skills properly working, you **need** to generate locales for your l
 
 - 🇺🇸 `en_US`
 - 🇫🇷 `fr_FR`
+- :es: `es_ES`
 
 You can generate them with `sudo raspi-config`. Going in the `Localisation Options` submenu, then in the `Change Locale` submenu, and selecting the locales you want to support. For instance, select `en_US UTF-8` if you want support for English. 
 

--- a/action-owm.py
+++ b/action-owm.py
@@ -184,6 +184,8 @@ if __name__ == "__main__":
         print "No API key in config.ini, you must setup an OpenWeatherMap API key for this skill to work"
     
     skill_locale = config.get("global", {"locale":"en_US"}).get("locale", u"en_US")
+    if skill_locale == u"":
+        skill_locale = u"en_US"
     skill = SnipsOWM(config["secret"]["api_key"],
             config["secret"]["default_location"],locale=skill_locale.decode('ascii'))
     

--- a/action-owm.py
+++ b/action-owm.py
@@ -184,7 +184,7 @@ if __name__ == "__main__":
     elif len(config.get("secret").get("api_key")) == 0:
         print "No API key in config.ini, you must setup an OpenWeatherMap API key for this skill to work"
     
-    skill_locale = config.get("global", {"locale":"en_US"}).get("locale", u"en_US")
+    skill_locale = config.get("secret", {"locale":"en_US"}).get("locale", u"en_US")
     
     if skill_locale == u"":
         print "No locale information is found!"

--- a/action-owm.py
+++ b/action-owm.py
@@ -9,6 +9,7 @@ from hermes_python.hermes import Hermes
 import hermes_python
 import io
 import os
+import sys
 from snipsowm.snipsowm import SnipsOWM
 
 CONFIGURATION_ENCODING_FORMAT = "utf-8"
@@ -184,8 +185,12 @@ if __name__ == "__main__":
         print "No API key in config.ini, you must setup an OpenWeatherMap API key for this skill to work"
     
     skill_locale = config.get("global", {"locale":"en_US"}).get("locale", u"en_US")
+    
     if skill_locale == u"":
-        skill_locale = u"en_US"
+        print "No locale information is found!"
+        print "Please edit 'config.ini' file, give either en_US, fr_FR or es_ES refering to the language of your assistant"
+        sys.exit(1)
+        
     skill = SnipsOWM(config["secret"]["api_key"],
             config["secret"]["default_location"],locale=skill_locale.decode('ascii'))
     

--- a/config.ini.default
+++ b/config.ini.default
@@ -1,5 +1,6 @@
 [global]
-locale=
+
 [secret]
 api_key=
+locale=
 default_location=


### PR DESCRIPTION
Fix:
When the `locale` is empty, it's detected as an empty `Unicode string` instead of `None`. So error occurs. Add checking. 

Add:
Updated readme with Spanish supporting