### PR TITLE
action-own: fix reading result string in French

### DIFF
--- a/action-owm.py
+++ b/action-owm.py
@@ -125,7 +125,7 @@ def searchWeatherForecastTemperature(hermes, intent_message):
     locality = getAnyLocality(intent_message)
     res = hermes.skill.speak_temperature(locality, datetime, granularity)
     current_session_id = intent_message.session_id
-    hermes.publish_end_session(current_session_id, res.decode("latin-1"))
+    hermes.publish_end_session(current_session_id, res.decode("utf8"))
 
 def searchWeatherForecastCondition(hermes, intent_message):
     datetime = getDateTime(intent_message)
@@ -140,7 +140,7 @@ def searchWeatherForecastCondition(hermes, intent_message):
                                Region=region, Country=country,
                                POI=geographical_poi)
     current_session_id = intent_message.session_id
-    hermes.publish_end_session(current_session_id, res.decode("latin-1"))
+    hermes.publish_end_session(current_session_id, res.decode("utf8"))
 
 def searchWeatherForecast(hermes, intent_message):
     datetime = getDateTime(intent_message)
@@ -156,7 +156,7 @@ def searchWeatherForecast(hermes, intent_message):
                                Region=region, Country=country,
                                POI=geographical_poi)
     current_session_id = intent_message.session_id
-    hermes.publish_end_session(current_session_id, res.decode("latin-1"))
+    hermes.publish_end_session(current_session_id, res.decode("utf8"))
 
 def searchWeatherForecastItem(hermes, intent_message):
     datetime = getDateTime(intent_message)
@@ -174,7 +174,7 @@ def searchWeatherForecastItem(hermes, intent_message):
                                  Country=country,
                                  POI=geographical_poi)
     current_session_id = intent_message.session_id
-    hermes.publish_end_session(current_session_id, res.decode("latin-1"))
+    hermes.publish_end_session(current_session_id, res.decode("utf8"))
 
 if __name__ == "__main__":
     config = read_configuration_file("config.ini")


### PR DESCRIPTION
I had the usual Python 2 encoding issues with this app, and the TTS literally reading the garbage it can produce.

I found out this "latin1" encoding was in contradiction with the encoding declared where the sentences are stored, e.g. https://github.com/snipsco/snips-skill-owm/blob/master/snipsowm/sentence_generator.py#L2

For completeness, my dev kit is configured to the locale fr_FR.UTF-8.

I can only encourage you to move to Python 3 but I have no idea how installed applications can be migrated. By writing specific migration code in setup.sh?